### PR TITLE
Prefix all variables with the role name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ See `vars/main.yml` for standard options:
     vsftpd_pasv_enable: 'YES'
     # end vsftpd settings
 
-    pwd_file: /etc/vsftpd
+    vsftpd_pwd_file: /etc/vsftpd
 
-    test_user_is_enable: no
-    test_user: k0st1an
-    test_user_password: 42
+    vsftpd_test_user_is_enable: no
+    vsftpd_test_user: k0st1an
+    vsftpd_test_user_password: 42
 
 Additionally you can optionally set:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,8 @@ vsftpd_write_enable: 'YES'
 vsftpd_pasv_enable: 'YES'
 # end vsftpd settings
 
-pwd_file: /etc/vsftpd
+vsftpd_pwd_file: /etc/vsftpd
 
-test_user_is_enable: no
-test_user: k0st1an
-test_user_password: 42
+vsftpd_test_user_is_enable: no
+vsftpd_test_user: k0st1an
+vsftpd_test_user_password: 42

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,8 +23,8 @@
 
 - name: add test user of the ftp
   tags: testuser
-  command: /sbin/vsftpd-user add {{ test_user }} {{ test_user_password }} creates=/etc/vsftpd
-  when: test_user_is_enable
+  command: /sbin/vsftpd-user add {{ vsftpd_test_user }} {{ vsftpd_test_user_password }} creates=/etc/vsftpd
+  when: vsftpd_test_user_is_enable
 
 # will be create backup file if already exist
 - name: copy config file of the vsftpd

--- a/templates/vsftpd-user.j2
+++ b/templates/vsftpd-user.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DB="{{ pwd_file }}"
+DB="{{ vsftpd_pwd_file }}"
 LOCAL_ROOT="{{ vsftpd_local_root }}"
 
 function usage() {

--- a/templates/vsftpd.pam.j2
+++ b/templates/vsftpd.pam.j2
@@ -1,6 +1,6 @@
 # PAM
 auth		requisite	pam_listfile.so		item=user sense=deny file=/etc/ftpusers onerr=fail
-auth		requisite	pam_pwdfile.so		pwdfile={{ pwd_file }}
+auth		requisite	pam_pwdfile.so		pwdfile={{ vsftpd_pwd_file }}
 auth		requisite	pam_nologin.so
 account		requisite	pam_permit.so
 session		requisite	pam_loginuid.so


### PR DESCRIPTION
Hi @k0st1an. Thanks for your work on this role.

This change prefixes all variables used with the role name, `vsftpd_`, as is suggested in the 'Good Practices' section at https://galaxy.ansible.com/intro.
