### PR TITLE
Unmount and remove unmanaged binds

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,9 @@
     - flags:
       skip_missing: true
 
+- include_tasks: unbind.yml
+  with_items: "{{ vsftpd_users }}"
+
 # will be create backup file if already exist
 - name: copy config file of the vsftpd
   template: src=vsftpd.conf.j2 dest=/etc/vsftpd.conf mode=644 backup=yes

--- a/tasks/unbind.yml
+++ b/tasks/unbind.yml
@@ -10,7 +10,7 @@
 
 - debug: msg="{{ vsftpd_local_root }}/{{ item.username }}/{{ inner_item | realpath | basename }}" verbosity=3
   with_items: "{{ contents.stdout_lines }}"
-  when: inner_item not in "{{ managed }}"
+  when: inner_item not in managed
   loop_control:
     loop_var: inner_item
 
@@ -21,7 +21,7 @@
     state: unmounted
     name: "{{ vsftpd_local_root }}/{{ item.username }}/{{ inner_item | realpath | basename }}"
   with_items: "{{ contents.stdout_lines }}"
-  when: inner_item not in "{{ managed }}"
+  when: inner_item not in managed
   loop_control:
     loop_var: inner_item
 
@@ -32,6 +32,6 @@
     state: absent
     name: "{{ vsftpd_local_root }}/{{ item.username }}/{{ inner_item | realpath | basename }}"
   with_items: "{{ contents.stdout_lines }}"
-  when: inner_item not in "{{ managed }}"
+  when: inner_item not in managed
   loop_control:
     loop_var: inner_item

--- a/tasks/unbind.yml
+++ b/tasks/unbind.yml
@@ -1,0 +1,37 @@
+---
+- shell: "ls -1 {{ vsftpd_local_root }}/{{ item.username }}"
+  register: contents
+
+- set_fact:
+    managed: "{{ managed | default([]) + [ inner_item.path ] }}"
+  with_items: "{{ item.bindpath }}"
+  loop_control:
+    loop_var: inner_item
+
+- debug: msg="{{ vsftpd_local_root }}/{{ item.username }}/{{ inner_item | realpath | basename }}" verbosity=3
+  with_items: "{{ contents.stdout_lines }}"
+  when: inner_item not in "{{ managed }}"
+  loop_control:
+    loop_var: inner_item
+
+- name: Unbind unmanaged paths - unmounted
+  mount:
+    opts: bind
+    fstype: none
+    state: unmounted
+    name: "{{ vsftpd_local_root }}/{{ item.username }}/{{ inner_item | realpath | basename }}"
+  with_items: "{{ contents.stdout_lines }}"
+  when: inner_item not in "{{ managed }}"
+  loop_control:
+    loop_var: inner_item
+
+- name: Unbind unmanaged paths - absent
+  mount:
+    opts: bind
+    fstype: none
+    state: absent
+    name: "{{ vsftpd_local_root }}/{{ item.username }}/{{ inner_item | realpath | basename }}"
+  with_items: "{{ contents.stdout_lines }}"
+  when: inner_item not in "{{ managed }}"
+  loop_control:
+    loop_var: inner_item


### PR DESCRIPTION
This PR is a followup to https://github.com/k0st1an/ansible-vsftpd/pull/5 .
This PR cleans up unmanaged binds, so, i.e. if

```
    vsftpd_users:
      - username: johndoe
        password: pa55w0rd
        bindpath:
          - path: "/var/www/vhosts/example.com"
          - path: "/var/www/vhosts/example.net"
```

creates the two bindpaths and later this gets reconfigured to

```
    vsftpd_users:
      - username: johndoe
        password: pa55w0rd
        bindpath:
          - path: "/var/www/vhosts/example.com"
```
the now unmanaged bind-mount to `/var/www/vhosts/example.net` gets now cleaned up and removed.
